### PR TITLE
Add DJD Agent Score — reputation scoring for agent payment trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ _Last updated: 2025-11-06_
 ### Agent Trust Rails
 **Visa's Trusted Agent Protocol** and **Mastercard's Agent Pay** both leverage **Web Bot Auth** for cryptographically signed agent identity during browse and payment flows.
 
+### Agent Reputation & Scoring
+- [DJD Agent Score](https://djd-agent-score.fly.dev) - Behavioral reputation scoring API for AI agent wallets on Base. Scores agents 0–100 across 5 dimensions using on-chain transaction patterns, sybil detection, and gaming velocity checks. x402-native monetization, MCP server distribution, and ERC-8004 compatible. [GitHub](https://github.com/jacobsd32-cpu/djd-agent-score)
+
 ### E-commerce Platforms
 - **Shopify** - AP2 & ACP support
 - **Etsy** - Live with ACP (Instant Checkout in ChatGPT)


### PR DESCRIPTION
## What this adds

A new **Agent Reputation & Scoring** subsection under Ecosystem & Partners → Agent Trust Rails, with an entry for [DJD Agent Score](https://djd-agent-score.fly.dev).

## Why it fits this list

This list covers the full agent payments stack: AP2, A2A, x402, ACP, and the trust infrastructure around them. DJD Agent Score fills the **reputation layer** — before an agent makes an x402 payment or AP2 mandate, it can check the counterparty's behavioral trust score.

- Scores agents 0–100 across 5 dimensions (identity, behavior, reliability, viability, capability)
- Derives scores from actual on-chain settlement history on Base
- 7 sybil detection heuristics + 5 gaming velocity detectors
- x402-native monetization, MCP server distribution
- ERC-8004 Reputation Registry compatible
- Already listed in the [Coinbase x402 ecosystem](https://x402.org/ecosystem) and [awesome-x402](https://github.com/xpaysh/awesome-x402)

## Placement rationale

Added alongside Visa's Trusted Agent Protocol and Mastercard's Agent Pay under Agent Trust Rails — these handle identity/auth, DJD handles behavioral reputation. Complementary layers of the trust stack.