### PR TITLE
Add Crypto Anomaly Signal API - live x402 service on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ _Last updated: 2025-11-06_
 - [QuickNode - Using x402 for Paywalls](https://www.quicknode.com/guides/infrastructure/how-to-use-x402-payment-required)
 - [Crossmint x402 Starter](https://github.com/Crossmint/crossmint-402-starter)
 
+#### Live x402 APIs
+- [Crypto Anomaly Signal API](https://frog03-20494.wykr.es/api/signals/paid) – Real-time crypto volume anomaly detection across 50+ tokens. $0.01 USDC per call via x402 on Base. Free tier available at `/api/signals/free`.
+
 #### SDKs & Libraries
 - [x402 Rust crates + Facilitator](https://github.com/x402-rs/x402-rs)
 - [Coinbase x402 Repository](https://github.com/coinbase/x402)


### PR DESCRIPTION
## What
Adds **Crypto Anomaly Signal API** under the x402 Implementation section as a live API example.

## Service Details
- **URL**: https://frog03-20494.wykr.es/api/signals/paid
- **What it does**: Real-time crypto volume anomaly detection across 50+ tokens. Returns JSON with anomaly scores, volume ratios, and price data.
- **Price**: $0.01 USDC per call via x402 on Base
- **Free tier**: Rate-limited access at `/api/signals/free`
- **Network**: Base (eip155:8453)

A live, working x402-enabled API demonstrating micropayments for financial data.