### PR TITLE
Add Azeth to x402 SDKs & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ _Last updated: 2025-11-06_
 #### SDKs & Libraries
 - [x402 Rust crates + Facilitator](https://github.com/x402-rs/x402-rs)
 - [Coinbase x402 Repository](https://github.com/coinbase/x402)
+- [Azeth](https://github.com/azeth-protocol) - Trust infrastructure for machine-to-machine payments: non-custodial ERC-4337 smart accounts with x402 settlement, on-chain reputation (ERC-8004), and service discovery via MCP server, TypeScript SDK, and CLI.
 
 ### ACP Implementation
 - [ACP: Get Started (OpenAI)](https://developers.openai.com/commerce/guides/get-started/)


### PR DESCRIPTION
Adds Azeth under Developer Tools & Starters → x402 Implementation → SDKs & Libraries.

Azeth provides developer tools for building x402-powered agent payment flows:
- x402 facilitator middleware for on-chain USDC settlement
- Non-custodial ERC-4337 smart accounts with spending guardrails
- On-chain reputation via ERC-8004 trust registry
- MCP server (8 tools), TypeScript SDK, CLI

- GitHub: https://github.com/azeth-protocol
- npm: [@azeth/sdk](https://www.npmjs.com/package/@azeth/sdk) | [@azeth/mcp-server](https://www.npmjs.com/package/@azeth/mcp-server)