### PR TITLE
Add x402-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@
 
 - [x402 Monorepo (GitHub)](https://github.com/coinbase/x402) — `@x402/core`, `@x402/evm`, `@x402/svm`, `@x402/axios`, `@x402/fetch`, `@x402/express`, `@x402/hono`, `@x402/next`, `@x402/paywall`
 - [x402 Rust crates + Facilitator](https://github.com/x402-rs/x402-rs)
+- [x402-proxy](https://github.com/cascade-protocol/x402-proxy) — `curl` for x402 paid APIs. Auto-pays HTTP 402 responses with USDC, with MCP stdio proxy for AI agents
 
 ### ACP Implementation
 


### PR DESCRIPTION
Adds x402-proxy to the x402 Implementation > SDKs & Libraries section.

**x402-proxy** is `curl` for x402 paid APIs - a CLI and library that auto-pays HTTP 402 responses with USDC, with an MCP stdio proxy for AI agents.

- [GitHub](https://github.com/cascade-protocol/x402-proxy)
- [npm](https://www.npmjs.com/package/x402-proxy)