### PR TITLE
Add x402 Wallet for Claude Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@
 - [MCP Server with x402](https://docs.cdp.coinbase.com/x402/mcp-server)
 - [QuickNode — Using x402 for Paywalls](https://www.quicknode.com/guides/infrastructure/how-to-use-x402-payment-required)
 - [Crossmint x402 Starter](https://github.com/Crossmint/crossmint-402-starter)
+- [x402 Wallet for Claude Desktop](https://github.com/402md/x402-wallet-for-claude-desktop) — Claude Desktop extension with x402 USDC payments on Stellar and Base. Automatic 402 handling with configurable spending limits.
 
 #### SDKs & Libraries
 


### PR DESCRIPTION
## What
Adds x402 Wallet for Claude Desktop to the x402 Implementation → Quickstarts section.

## Why
A Claude Desktop extension that enables x402 USDC payments on both **Stellar** and **Base** networks. Relevant to this list because:

- **x402 native** — implements the x402 protocol for automatic HTTP 402 payment handling
- **Multi-chain** — supports Stellar and Base (Coinbase L2) for USDC payments
- **Claude Desktop extension** — one-click .mcpb install for Claude Desktop
- **Budget safety** — configurable per-call and daily spending limits

## Quality checklist
- [x] Actively maintained
- [x] Clear documentation
- [x] MIT licensed
- [x] x402-specific
- [x] All links verified