### PR TITLE
Add tx402.ai — live x402 LLM inference service

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@
 
 #### Live x402 Services
 
-- [tx402.ai](https://tx402.ai) — Agent-native LLM inference gateway. 20+ EU-hosted models (DeepSeek, Qwen, Llama, GLM, Mixtral) via x402 USDC micropayments on Base. OpenAI-compatible API, SSE streaming, GDPR-compliant, zero data retention. No API keys — wallet is auth. [Source](https://github.com/Tensorix-ai/agent-gateway)
+- [tx402.ai](https://tx402.ai) — Agent-native LLM inference gateway. 20+ EU-hosted models (DeepSeek, Qwen, Llama, GLM, Mixtral) via x402 USDC micropayments on Base. OpenAI-compatible API, SSE streaming, GDPR-compliant, zero data retention. No API keys — wallet is auth.
 
 #### SDKs & Libraries
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@
 - [QuickNode — Using x402 for Paywalls](https://www.quicknode.com/guides/infrastructure/how-to-use-x402-payment-required)
 - [Crossmint x402 Starter](https://github.com/Crossmint/crossmint-402-starter)
 
+#### Live x402 Services
+
+- [tx402.ai](https://tx402.ai) — Agent-native LLM inference gateway. 20+ EU-hosted models (DeepSeek, Qwen, Llama, GLM, Mixtral) via x402 USDC micropayments on Base. OpenAI-compatible API, SSE streaming, GDPR-compliant, zero data retention. No API keys — wallet is auth. [Source](https://github.com/Tensorix-ai/agent-gateway)
+
 #### SDKs & Libraries
 
 - [x402 Monorepo (GitHub)](https://github.com/coinbase/x402) — `@x402/core`, `@x402/evm`, `@x402/svm`, `@x402/axios`, `@x402/fetch`, `@x402/express`, `@x402/hono`, `@x402/next`, `@x402/paywall`


### PR DESCRIPTION
Adds [tx402.ai](https://tx402.ai) under the x402 Implementation section as a live service.

x402 payment gateway for agent-native EU LLM inference. 20+ models with USDC micropayments on Base. OpenAI-compatible, SSE streaming, GDPR-compliant.

- Live: https://tx402.ai
- Source: https://github.com/Tensorix-ai/agent-gateway