### PR TITLE
Add ZKProofport to Identity / Interop section

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@
 - [Web Bot Auth — Architecture Draft (IETF)](https://datatracker.ietf.org/doc/html/draft-meunier-web-bot-auth-architecture) — Agent identity via HTTP Message Signatures
 - [Web Bot Auth — Directory Draft (IETF)](https://datatracker.ietf.org/doc/html/draft-meunier-web-bot-auth-directory) — Directory for verified bot identities
 - [Web Bot Auth (Cloudflare Developer Docs)](https://developers.cloudflare.com/bots/reference/bot-verification/web-bot-auth/)
+- [ZKProofport](https://zkproofport.app) — Zero-knowledge proof generation for AI agent identity. Lets agents prove Coinbase KYC, Country, Google OIDC, Google Workspace, or Microsoft 365 affiliation via x402-paid TEE proving on Base. ERC-8004 registered, A2A compatible. NPM: `@zkproofport-ai/mcp`. Reference app: [OpenStoa](https://github.com/zkproofport/openstoa) (1st place — The Synthesis Hackathon 2026)
 
 ---
 


### PR DESCRIPTION
Adds ZKProofport to the **Identity / Interop** section.

ZKProofport provides zero-knowledge proof generation for AI agent identity. It lets agents prove Coinbase KYC, Country, Google OIDC, Google Workspace, or Microsoft 365 affiliation **without revealing personal information**, paid via x402 micropayments on Base.

**Why it fits this list:**
- **x402 integration**: Server-side proof generation paid via USDC on Base
- **A2A compatible**: Hosts agent card at `/.well-known/agent-card.json`
- **ERC-8004 registered**: Token ID 25331 on Base Mainnet
- **Production architecture**: AWS Nitro Enclave TEE, Noir circuits (Aztec)
- **Open source MIT**: `@zkproofport-ai/mcp` (NPM)

**Reference application**: [OpenStoa](https://github.com/zkproofport/openstoa) — 1st place at The Synthesis Hackathon ("Agents That Keep Secrets" track, April 2026, 506 projects, 1500+ builders).