### PR TITLE
feat: add PoolPulse — live x402 service on Base

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@
 - [QuickNode — Using x402 for Paywalls](https://www.quicknode.com/guides/infrastructure/how-to-use-x402-payment-required)
 - [Crossmint x402 Starter](https://github.com/Crossmint/crossmint-402-starter)
 
+#### Live Services
+
+- [PoolPulse](https://poolpulse.poolpulse.workers.dev) — x402-payable DeFi execution signals API on Base. CLMM slippage, MEV scoring, routing hints for 33 Uniswap V3 + Aerodrome pools. Built with Hono + x402/hono. Pay per call ($0.001–$0.25 USDC). ([OpenAPI](https://poolpulse.poolpulse.workers.dev/openapi.json), [Examples](https://github.com/HadiFrt20/poolpulse-agent-example))
+
 #### SDKs & Libraries
 
 - [x402 Monorepo (GitHub)](https://github.com/coinbase/x402) — `@x402/core`, `@x402/evm`, `@x402/svm`, `@x402/axios`, `@x402/fetch`, `@x402/express`, `@x402/hono`, `@x402/next`, `@x402/paywall`


### PR DESCRIPTION
Adds PoolPulse to the x402 Implementation section as a live service example.

**What:** Pre-trade DeFi execution signals API — CLMM slippage, MEV scoring, routing hints for 33 Uniswap V3 + Aerodrome pools on Base.

**x402 integration:** Built with `@x402/hono`. All paid endpoints return 402 with PAYMENT-REQUIRED headers. Three payment paths: x402 per-call, pre-funded credit (X-Wallet + topup), and direct USDC deposit.

**Live:** https://poolpulse.poolpulse.workers.dev