### PR TITLE
Add Radius Network to Crypto & Web3

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@ Officially reported supporters include Shopify, Etsy, Salesforce, Mastercard, Pa
 
 - **Coinbase** — x402 creator, AP2 partner
 - **Tempo Labs** — MPP co-author (Paradigm-backed, payments-optimized L1)
+- **Radius Network** — x402-compatible stablecoin L1 for agentic micropayments
 
 ---
 


### PR DESCRIPTION
## Add Radius Network to Crypto & Web3

Radius Network is an x402-compatible stablecoin L1 purpose-built for agentic micropayments. Radius mainnet launched March 2026 with sub-second finality and sub-penny fees. x402 settlement infrastructure (Permit2, x402ExactPermit2Proxy) is deployed at canonical addresses.

- Website: https://radiustech.xyz
- x402 integration docs: https://docs.radiustech.xyz/developer-resources/x402-integration

### Checklist
- [x] Resource is directly related to AP2/A2A/x402/agentic commerce
- [x] Link works and loads properly
- [x] Content is substantial and valuable (not just promotional)
- [x] Resource isn't already listed
- [x] Description follows our format and guidelines
- [x] Placed in the correct section