### PR TITLE
Add Voidly Pay — open ledger spanning x402 + A2A + AP2

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@
 - [x402 Monorepo (GitHub)](https://github.com/coinbase/x402) — `@x402/core`, `@x402/evm`, `@x402/svm`, `@x402/axios`, `@x402/fetch`, `@x402/express`, `@x402/hono`, `@x402/next`, `@x402/paywall`
 - [x402 Rust crates + Facilitator](https://github.com/x402-rs/x402-rs)
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) — `curl` for x402 paid APIs. Auto-pays HTTP 402 responses with USDC, with MCP stdio proxy for AI agents
+- [Voidly Pay](https://github.com/voidly-ai/voidly-pay) — Open off-chain credit ledger for agent-to-agent payments. Ships bridges for x402 and A2A; Ed25519-signed envelopes, escrow, hire workflow. 9 framework adapters (LangChain, CrewAI, AutoGen, LlamaIndex, Haystack, Vercel AI, OpenAI-compat, x402, A2A).
 
 ### ACP Implementation
 


### PR DESCRIPTION
## What

Adds [Voidly Pay](https://github.com/voidly-ai/voidly-pay) to the `Developer Tools & Starters` → `x402 Implementation` → `SDKs & Libraries` section.

## Why it fits this list

Voidly Pay is one of the few agent-payment implementations that spans **multiple protocols at once**:

- **x402 bridge** — `adapters/x402` translates HTTP 402 payment requirements into signed envelopes
- **A2A bridge** — `adapters/a2a` exposes capabilities as A2A agent cards with escrow-backed task execution
- **AP2** — on the roadmap (mandate verification via the existing envelope signing primitive)

## Core primitives

- `transfer` — Ed25519-signed envelopes, atomic settlement
- `escrow` — open → release / refund, with capability binding
- `receipt` — work attestation
- `hire` — atomic open-escrow + record-hire workflow
- `capability` — publishable service listings (discoverable across adapters)
- `faucet` — onboarding credits

## Adapters (9 total)

LangChain, CrewAI, AutoGen, LlamaIndex, Haystack, Vercel AI, OpenAI-compat, x402, A2A.

## Entry added

```markdown
- [Voidly Pay](https://github.com/voidly-ai/voidly-pay) — Open off-chain credit ledger for agent-to-agent payments. Ships bridges for x402 and A2A; Ed25519-signed envelopes, escrow, hire workflow. 9 framework adapters (LangChain, CrewAI, AutoGen, LlamaIndex, Haystack, Vercel AI, OpenAI-compat, x402, A2A).
```

## Links

- Source: https://github.com/voidly-ai/voidly-pay
- Landing: https://voidly.ai/pay

Maintainer: @EmperorMew