### PR TITLE
Add AlgoVoi as reference implementation for AP2, x402, and MPP

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@
 ### AP2 Implementation
 
 - [AP2 Python & Android Samples](https://github.com/google-agentic-commerce/AP2)
+- [AlgoVoi AP2 Facilitator](https://api.algovoi.co.uk/.well-known/agent.json) — Live production AP2 facilitator with on-chain USDC settlement. Spans Algorand, VOI, Hedera, Stellar, Base, Solana, Tempo on a single endpoint. Solana flow uses Solana Pay `reference` pubkey binding for cryptographic tx↔PaymentMandate correlation. ([Source](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters))
 
 ### x402 Implementation
 
@@ -222,6 +223,7 @@
 - [QuickNode — Using x402 for Paywalls](https://www.quicknode.com/guides/infrastructure/how-to-use-x402-payment-required)
 - [Crossmint x402 Starter](https://github.com/Crossmint/crossmint-402-starter)
 - [x402 Wallet for Claude Desktop](https://github.com/402md/x402-wallet-for-claude-desktop) — Claude Desktop extension with x402 USDC payments on Stellar and Base. Automatic 402 handling with configurable spending limits.
+- [AlgoVoi Multi-Chain x402 Facilitator](https://api.algovoi.co.uk) — Single-endpoint x402 facilitator spanning EVM (Base, Tempo), SVM (Solana), AVM (Algorand, VOI), Stellar, and Hedera. Native Solana Pay `reference` pubkey binding. Agent card at `/.well-known/agent.json`. ([MCP adapter](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters))
 
 #### Live Services
 
@@ -245,6 +247,7 @@
 - [MPP SDKs](https://mpp.dev/overview) — Official TypeScript SDK (`mppx`) with middleware for Hono, Express, Next.js, Elysia
 - [Stripe: Machine Payments with MPP](https://docs.stripe.com/payments/machine/mpp) — Implementation with PaymentIntents
 - [Visa Card Spec & SDK for MPP](https://corporate.visa.com/en/sites/visa-perspectives/innovation/visa-card-specification-sdk-for-machine-payments-protocol.html) — Card-based MPP transactions via tokenized network payment tokens settling over existing card infrastructure
+- [AlgoVoi MPP Service](https://api.algovoi.co.uk) — Registered in the MPP service directory ([tempoxyz/mpp #556](https://github.com/tempoxyz/mpp/pull/556)) with full 7-chain on-chain USDC coverage. Non-custodial, tenant-scoped.
 
 ### A2A Implementation
 


### PR DESCRIPTION
Three additions covering all three payment-protocol families this list curates:

- **AP2 Implementation:** AlgoVoi as a live facilitator with 7-chain USDC settlement + Solana Pay `reference` pubkey binding for tx<->PaymentMandate correlation.
- **x402 Implementation (Live Services):** Single-endpoint multi-chain x402 facilitator spanning EVM (Base, Tempo), SVM (Solana), AVM (Algorand, VOI), Stellar, Hedera.
- **MPP Implementation:** Registered service in the official MPP directory ([tempoxyz/mpp #556](https://github.com/tempoxyz/mpp/pull/556)).

AlgoVoi is the only entry that implements all three protocols on the same URL, which makes it a natural cross-reference for agents deciding between protocols. Production at api.algovoi.co.uk with open-source [MCP adapter](https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters).

---

*AlgoVoi (chopmob-cloud) - chopmob@gmail.com - Acquisition enquiries: https://docs.algovoi.co.uk/acquisition*