### PR TITLE
Add @tensorfeed/x402-base-mcp under x402 SDKs & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@
 - [x402 Monorepo (GitHub)](https://github.com/coinbase/x402) — `@x402/core`, `@x402/evm`, `@x402/svm`, `@x402/axios`, `@x402/fetch`, `@x402/express`, `@x402/hono`, `@x402/next`, `@x402/paywall`
 - [x402 Rust crates + Facilitator](https://github.com/x402-rs/x402-rs)
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) — `curl` for x402 paid APIs. Auto-pays HTTP 402 responses with USDC, with MCP stdio proxy for AI agents
+- [@tensorfeed/x402-base-mcp](https://www.npmjs.com/package/@tensorfeed/x402-base-mcp) — Read-only Base mainnet chain reader purpose-built for x402 payment verification. Eleven MCP tools: verify on-chain that a USDC settlement matches a claimed x402 receipt, parse publisher `/.well-known/x402` manifests, list recent USDC payments to an address, check AFTA federation status. No private keys, no signing, no broadcasts. ([GitHub](https://github.com/RipperMercs/tensorfeed-x402-base-mcp), [MCP registry](https://registry.modelcontextprotocol.io/v0/servers/ai.tensorfeed/x402-base-mcp))
 
 ### ACP Implementation
 


### PR DESCRIPTION
Adds [@tensorfeed/x402-base-mcp](https://www.npmjs.com/package/@tensorfeed/x402-base-mcp) right after x402-proxy in the x402 Implementation → SDKs & Libraries section.

**What it is:** Read-only Base mainnet chain reader purpose-built for x402 payment verification. Differs from existing entries: x402-proxy bridges agents to PAY for x402 APIs; this MCP lets agents independently VERIFY that an x402 payment receipt actually settled on-chain. Complementary use case.

**Eleven tools:** balance, usdc_balance, get_tx_receipt, block_number, call, recent_transfers, verify_x402_settlement, parse_x402_manifest, usdc_recent_payments_to, verify_afta_federation, tf_payment_lookup.

**Security profile:** No private keys, no signing, no broadcasts (verification-only). MIT. Published with cryptographic provenance via GitHub Actions OIDC. Socket.dev: Supply Chain 79, Quality 100, Vulnerability 100, License 100, Maintenance 86.

**MCP registry:** `ai.tensorfeed/x402-base-mcp`