### PR TITLE
Add switchboard to x402 Implementation > SDKs & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@
 - [x402 Monorepo (GitHub)](https://github.com/coinbase/x402) — `@x402/core`, `@x402/evm`, `@x402/svm`, `@x402/axios`, `@x402/fetch`, `@x402/express`, `@x402/hono`, `@x402/next`, `@x402/paywall`
 - [x402 Rust crates + Facilitator](https://github.com/x402-rs/x402-rs)
 - [x402-proxy](https://github.com/cascade-protocol/x402-proxy) — `curl` for x402 paid APIs. Auto-pays HTTP 402 responses with USDC, with MCP stdio proxy for AI agents
+- [switchboard (kcolbchain)](https://github.com/kcolbchain/switchboard) — Python middleware + on-chain escrow for agent-to-agent payments. Server-side `X402Middleware` (FastAPI/Flask), gas-budget tracker (per-hour/per-day caps), reorg-safe nonce manager, and Solidity `AgentEscrow` with timeout/refund. ZAP binary wire (~10× smaller than JSON) for high-volume A2A. Protocol-agnostic substrate (x402 + escrow shipping; MPP/AP2 in flight). MIT.
 
 ### ACP Implementation
 


### PR DESCRIPTION
## What

Adds [switchboard](https://github.com/kcolbchain/switchboard) under **Developer Tools & Starters > x402 Implementation > SDKs & Libraries**.

## One-line addition

```markdown
- [switchboard (kcolbchain)](https://github.com/kcolbchain/switchboard) — Python middleware + on-chain escrow for agent-to-agent payments. Server-side `X402Middleware` (FastAPI/Flask), gas-budget tracker (per-hour/per-day caps), reorg-safe nonce manager, and Solidity `AgentEscrow` with timeout/refund. ZAP binary wire (~10× smaller than JSON) for high-volume A2A. Protocol-agnostic substrate (x402 + escrow shipping; MPP/AP2 in flight). MIT.
```

## Why it fits this list specifically

This list covers the protocol landscape — x402 / AP2 / A2A / MPP / ACP — and switchboard is **explicitly protocol-agnostic**, designed to land x402 + escrow today and MPP / AP2 next. That makes it a natural fit for a list that catalogues the full payment-protocol stack rather than any single one.

Concrete x402 surface:
- `switchboard/x402_middleware.py` — server-side HTTP 402 middleware (FastAPI/Flask), verifies `X-PAYMENT`, emits `accepts[]`.
- `switchboard/zap_transport.py` — binary wire (over [luxfi/zap](https://github.com/luxfi/zap)) for high-volume A2A.
- `switchboard/gas_budget.py` + `gas_tracker.py` — hard per-hour/per-day spend caps.
- `switchboard/nonce_manager.py` — reorg-safe nonce manager.
- `contracts/AgentEscrow.sol` + `src/payment_protocol.py` — Solidity escrow with timeout + challenge period.

## Checklist

- [x] Single-line addition; format matches existing entries
- [x] Resource is actively maintained (recent merged PRs from external contributors)
- [x] MIT licensed, link tested
- [x] Placed in the most relevant subsection