### PR TITLE
feat: add SolSigs live x402 service

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@
 
 - [PoolPulse](https://poolpulse.poolpulse.workers.dev) — x402-payable DeFi execution signals API on Base. CLMM slippage, MEV scoring, routing hints for 33 Uniswap V3 + Aerodrome pools. Built with Hono + x402/hono. Pay per call ($0.001–$0.25 USDC). ([OpenAPI](https://poolpulse.poolpulse.workers.dev/openapi.json), [Examples](https://github.com/HadiFrt20/poolpulse-agent-example))
 
+- [SolSigs](https://solsigs.com) — Live Solana data API for AI agents via x402 micropayments in USDC. 6 endpoints: DEX feeds, arbitrage scanning, wallet intelligence, launch detection, LLM summarizer, RPC balancing ($0.001–$0.010). Custom x402 middleware, self-hosted. ([Discover](https://solsigs.com/discover), [x402 JSON](https://solsigs.com/.well-known/x402.json))
+
 #### SDKs & Libraries
 
 - [x402 Monorepo (GitHub)](https://github.com/coinbase/x402) — `@x402/core`, `@x402/evm`, `@x402/svm`, `@x402/axios`, `@x402/fetch`, `@x402/express`, `@x402/hono`, `@x402/next`, `@x402/paywall`


### PR DESCRIPTION
Add SolSigs — a live, production Solana data API that sells real-time blockchain intelligence to AI agents via x402 micropayments in USDC.

**6 paid endpoints:**
- /dex — DEX price feeds ($0.002)
- /arb — Arbitrage scanner ($0.010)
- /wallet — Wallet intelligence ($0.005)
- /launches — Token launch detector ($0.003)
- /summary — On-chain LLM summarizer ($0.008)
- /rpc — RPC load balancer ($0.001)

**Key details:**
- Custom x402 Express middleware (no external facilitator)
- Self-hosted on Hetzner, Node.js + PM2
- Live and serving traffic at https://solsigs.com
- Agent discovery: /discover, x402.json