### PR TITLE
Add The Stall — live x402 capability chassis (Live Services)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@
 
 - [PoolPulse](https://poolpulse.poolpulse.workers.dev) — x402-payable DeFi execution signals API on Base. CLMM slippage, MEV scoring, routing hints for 33 Uniswap V3 + Aerodrome pools. Built with Hono + x402/hono. Pay per call ($0.001–$0.25 USDC). ([OpenAPI](https://poolpulse.poolpulse.workers.dev/openapi.json), [Examples](https://github.com/HadiFrt20/poolpulse-agent-example))
 - [Coinbase x402 Bazaar](https://docs.cdp.coinbase.com/x402/bazaar) — Discovery layer / MCP server exposing 10,000+ x402-payable endpoints that agents can search, discover, and pay for autonomously (also surfaced via AWS Bedrock AgentCore Gateway)
+- [The Stall](https://the-stall.intuitek.ai) — x402 capability chassis by IntuiTek¹ with 172 pay-per-call capabilities on Base mainnet: financial data, crypto intel, DeFi analytics, compliance tools, and more. USDC via Coinbase CDP facilitator. MCP-compatible. ([Agent Card](https://the-stall.intuitek.ai/.well-known/agent.json), [Health](https://the-stall.intuitek.ai/health))
 
 #### SDKs & Libraries
 


### PR DESCRIPTION
Adds The Stall to the Live Services section under x402 Implementation.

The Stall is a domain-agnostic x402 capability chassis by IntuiTek¹, live on Base mainnet with three priced endpoints:

- **US stock prices** — $0.030/call
- **Market intelligence** — $0.50/call
- **Concentration-risk scoring** — $0.10/call (HHI-based analysis for x402 wallet addresses)

Payment via USDC on Base mainnet, Coinbase CDP facilitator. A2A-compatible: publishes an agent card at `/.well-known/agent.json` for discovery.

Website: https://the-stall.intuitek.ai
Agent Card: https://the-stall.intuitek.ai/.well-known/agent.json