### PR TITLE
Add The STALL — 210-capability x402 data intelligence MCP server (v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@
 
 - [PoolPulse](https://poolpulse.poolpulse.workers.dev) — x402-payable DeFi execution signals API on Base. CLMM slippage, MEV scoring, routing hints for 33 Uniswap V3 + Aerodrome pools. Built with Hono + x402/hono. Pay per call ($0.001–$0.25 USDC). ([OpenAPI](https://poolpulse.poolpulse.workers.dev/openapi.json), [Examples](https://github.com/HadiFrt20/poolpulse-agent-example))
 - [Coinbase x402 Bazaar](https://docs.cdp.coinbase.com/x402/bazaar) — Discovery layer / MCP server exposing 10,000+ x402-payable endpoints that agents can search, discover, and pay for autonomously (also surfaced via AWS Bedrock AgentCore Gateway)
-- [The Stall](https://the-stall.intuitek.ai) — x402 capability chassis by IntuiTek¹ with 172 pay-per-call capabilities on Base mainnet: financial data, crypto intel, DeFi analytics, compliance tools, and more. USDC via Coinbase CDP facilitator. MCP-compatible. ([Agent Card](https://the-stall.intuitek.ai/.well-known/agent.json), [Health](https://the-stall.intuitek.ai/health))
+- [The Stall](https://the-stall.intuitek.ai) — x402 capability chassis by IntuiTek¹ with 201 pay-per-call capabilities on Base mainnet: financial data (US/intl equities, options, ETFs), crypto intel, DeFi analytics, social signals, compliance tools, and more. USDC via Coinbase CDP facilitator. MCP-compatible. ([Agent Card](https://the-stall.intuitek.ai/.well-known/agent.json), [Health](https://the-stall.intuitek.ai/health))
 
 #### SDKs & Libraries
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@
 
 - [PoolPulse](https://poolpulse.poolpulse.workers.dev) — x402-payable DeFi execution signals API on Base. CLMM slippage, MEV scoring, routing hints for 33 Uniswap V3 + Aerodrome pools. Built with Hono + x402/hono. Pay per call ($0.001–$0.25 USDC). ([OpenAPI](https://poolpulse.poolpulse.workers.dev/openapi.json), [Examples](https://github.com/HadiFrt20/poolpulse-agent-example))
 - [Coinbase x402 Bazaar](https://docs.cdp.coinbase.com/x402/bazaar) — Discovery layer / MCP server exposing 10,000+ x402-payable endpoints that agents can search, discover, and pay for autonomously (also surfaced via AWS Bedrock AgentCore Gateway)
-- [The Stall](https://the-stall.intuitek.ai) — x402 capability chassis by IntuiTek¹ with 201 pay-per-call capabilities on Base mainnet: financial data (US/intl equities, options, ETFs), crypto intel, DeFi analytics, social signals, compliance tools, and more. USDC via Coinbase CDP facilitator. MCP-compatible. ([Agent Card](https://the-stall.intuitek.ai/.well-known/agent.json), [Health](https://the-stall.intuitek.ai/health))
+- [The STALL](https://the-stall.intuitek.ai) — 207-capability data intelligence MCP with x402 micropayments. Financial markets, crypto, DeFi, options flow, macro, and real-world intelligence — pay-per-call in USDC on Base, no subscription required. [[207 caps]](https://the-stall.intuitek.ai/health)
 
 #### SDKs & Libraries
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@
 
 - [PoolPulse](https://poolpulse.poolpulse.workers.dev) — x402-payable DeFi execution signals API on Base. CLMM slippage, MEV scoring, routing hints for 33 Uniswap V3 + Aerodrome pools. Built with Hono + x402/hono. Pay per call ($0.001–$0.25 USDC). ([OpenAPI](https://poolpulse.poolpulse.workers.dev/openapi.json), [Examples](https://github.com/HadiFrt20/poolpulse-agent-example))
 - [Coinbase x402 Bazaar](https://docs.cdp.coinbase.com/x402/bazaar) — Discovery layer / MCP server exposing 10,000+ x402-payable endpoints that agents can search, discover, and pay for autonomously (also surfaced via AWS Bedrock AgentCore Gateway)
+- [The Stall](https://the-stall.intuitek.ai) — x402 capability chassis by IntuiTek¹ with 172 pay-per-call capabilities on Base mainnet: financial data, crypto intel, DeFi analytics, compliance tools, and more. USDC via Coinbase CDP facilitator. MCP-compatible. ([Agent Card](https://the-stall.intuitek.ai/.well-known/agent.json), [Health](https://the-stall.intuitek.ai/health))
 
 #### SDKs & Libraries
 


### PR DESCRIPTION
## Addition

Adds [The STALL](https://the-stall.intuitek.ai) to the **x402 Live Services** section.

The STALL is a live x402 pay-per-call data intelligence MCP server on Base mainnet:

- **210 capabilities** across US equities, ETF holdings, DeFi analytics, options flow (GEX), crypto, macro indicators, geopolitical data, real-world intelligence, X/Twitter intel, and Solana meme radar
- **Payment via x402 protocol** — per-call pricing in USDC on Base, no subscription required
- **MCP-native** — connects via standard MCP protocol (`/mcp` endpoint)
- **Registered on CDP Bazaar** — discoverable by any x402-aware agent

### Verification
```bash
curl https://the-stall.intuitek.ai/health
# Returns 210 capabilities with x402 pricing metadata
```

git: d25c40a | version: v4.64.0 | caps: 210

Built by [IntuiTek¹](https://intuitek.ai).