### PR TITLE
feat: add Privacy & Compliance section with TrustBoost PII Sanitizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ Officially reported supporters include Shopify, Etsy, Salesforce, Mastercard, Pa
 
 ---
 
+
+## 🔒 Privacy & Compliance Tools
+
+- [TrustBoost PII Sanitizer](https://github.com/teodorofodocrispin-cmyk/TrustBoost-PII-Sanitizer) — x402-native PII sanitization layer for agentic pipelines. Sanitizes text before it reaches LLMs or payment endpoints. Returns sanitized content + safety score + risk category. Proof of Sanitization on Solana via Helius. 8 languages including LATAM (RFC, CUIT, CPF). EU AI Act compliant. Try free: `tx_hash=TRIAL`.
+
+
 ## 📰 News & Analysis
 
 ### Major Launches & Milestones


### PR DESCRIPTION
## What this adds

A new `Privacy & Compliance` section — the first in this collection.

## Why it belongs here

Agentic commerce payloads increasingly carry raw PII — names, emails, national IDs, financial data. The list covers payment protocols extensively but has no privacy layer entry. This is a genuine gap.

## Entry added

TrustBoost PII Sanitizer — open-source, x402-native PII sanitization for agentic pipelines. Proof of Sanitization on Solana. 8 languages including LATAM (RFC, CUIT, CPF). EU AI Act compliant. 50 free: tx_hash=TRIAL.