### PR TITLE
Add The STALL to x402 Live Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@
 #### Live Services
 
 - [PoolPulse](https://poolpulse.poolpulse.workers.dev) — x402-payable DeFi execution signals API on Base. CLMM slippage, MEV scoring, routing hints for 33 Uniswap V3 + Aerodrome pools. Built with Hono + x402/hono. Pay per call ($0.001–$0.25 USDC). ([OpenAPI](https://poolpulse.poolpulse.workers.dev/openapi.json), [Examples](https://github.com/HadiFrt20/poolpulse-agent-example))
+- [The STALL](https://the-stall.intuitek.ai) — 207-capability data intelligence MCP with x402 micropayments. Financial markets, crypto, DeFi, options flow, macro, and real-world intelligence — pay-per-call in USDC on Base, no subscription required. [[207 caps]](https://the-stall.intuitek.ai/health)
 
 #### SDKs & Libraries
 


### PR DESCRIPTION
## The STALL

Adds **The STALL** to the **x402 Implementation → Live Services** section.

**URL:** https://the-stall.intuitek.ai  
**Caps:** 207 capabilities  
**Payment:** x402 protocol (USDC on Base)

### Why it fits here

The STALL is a live x402-enabled MCP server: AI agents call capabilities and pay per-call in USDC using x402. It's registered on the **Coinbase CDP Bazaar** (the discovery layer already listed in this section). No subscription required — pay exactly what you use.

Capabilities include financial markets, crypto/DeFi, options flow, macro data, and real-world intelligence.

### Verification
```bash
curl https://the-stall.intuitek.ai/health
# Returns 207 capabilities with x402 pricing metadata
```

Built by [IntuiTek¹](https://intuitek.ai).