### PR TITLE
Add CYBERDYNE under x402 Implementation > Live Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@
 
 - [PoolPulse](https://poolpulse.poolpulse.workers.dev) — x402-payable DeFi execution signals API on Base. CLMM slippage, MEV scoring, routing hints for 33 Uniswap V3 + Aerodrome pools. Built with Hono + x402/hono. Pay per call ($0.001–$0.25 USDC). ([OpenAPI](https://poolpulse.poolpulse.workers.dev/openapi.json), [Examples](https://github.com/HadiFrt20/poolpulse-agent-example))
 - [Coinbase x402 Bazaar](https://docs.cdp.coinbase.com/x402/bazaar) — Discovery layer / MCP server exposing 10,000+ x402-payable endpoints that agents can search, discover, and pay for autonomously (also surfaced via AWS Bedrock AgentCore Gateway)
+- [CYBERDYNE](https://cyberdyne-os.xyz) — Engagement marketplace on Base where AI agents and communities fund quests (follows, reposts, replies, quotes, original posts); verified-X humans complete them and are paid per approved action from a non-custodial x402 auth-capture escrow, in USDC, BNKR, or any Bankr-launched token. MCP server published as [`cyberdyne-mcp`](https://www.npmjs.com/package/cyberdyne-mcp) (`npx -y cyberdyne-mcp`); source on [GitHub](https://github.com/Cyberdyne-OS/cyberdyne-mcp).
 
 #### SDKs & Libraries
 


### PR DESCRIPTION
Adds **CYBERDYNE** to *Developer Tools & Starters > x402 Implementation > Live Services*.

CYBERDYNE is an engagement marketplace on Base where AI agents and communities fund quests (follows, reposts, replies, quotes, original posts); verified-X humans complete them and are paid per approved action from a non-custodial x402 auth-capture escrow — in USDC, BNKR, or any Bankr-launched token. The budget is frozen on-chain at deploy and each approved action captures the full reward straight to the human; nothing is held custodially.

- Live: https://cyberdyne-os.xyz
- MCP server (npm): `cyberdyne-mcp` — `npx -y cyberdyne-mcp`
- Source (MIT): https://github.com/Cyberdyne-OS/cyberdyne-mcp

Placed beside the other live x402 services (PoolPulse, Coinbase x402 Bazaar, CardZero). One-line entry, factual, no metrics or marketing claims.