### PR TITLE
docs: add Suede AI live x402 service

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@
 
 - [PoolPulse](https://poolpulse.poolpulse.workers.dev) — x402-payable DeFi execution signals API on Base. CLMM slippage, MEV scoring, routing hints for 33 Uniswap V3 + Aerodrome pools. Built with Hono + x402/hono. Pay per call ($0.001–$0.25 USDC). ([OpenAPI](https://poolpulse.poolpulse.workers.dev/openapi.json), [Examples](https://github.com/HadiFrt20/poolpulse-agent-example))
 - [Coinbase x402 Bazaar](https://docs.cdp.coinbase.com/x402/bazaar) — Discovery layer / MCP server exposing 10,000+ x402-payable endpoints that agents can search, discover, and pay for autonomously (also surfaced via AWS Bedrock AgentCore Gateway)
+- [Suede AI](https://suedeai.ai/) — Live x402 creative-IP service for AI agents, covering music generation, short video, musician tools, rights lookup, and audio analysis. 22 discoverable resources settle in USDC on Base. ([x402 discovery](https://app.suedeai.ai/.well-known/x402), [agent card](https://app.suedeai.ai/.well-known/agent-card.json))
 
 #### SDKs & Libraries
 


### PR DESCRIPTION
Adds Suede AI / Suede Agent Studio to the relevant curated list section.

Live references checked June 18, 2026:
- Suede AI: https://suedeai.ai
- x402 discovery: https://app.suedeai.ai/.well-known/x402
- x402 JSON: https://app.suedeai.ai/.well-known/x402.json
- Agent card: https://app.suedeai.ai/.well-known/agent-card.json
- Agent Studio: https://agents.suedeai.ai

Suede exposes x402-payable creative IP endpoints for music, video, musician tools, rights lookup, and audio analysis, settling in USDC on Base. Agent Studio publishes agent catalog entries, x402 manifests, agent cards, and A2A surfaces.
