### PR TITLE
feat: add Intelica — live x402 competitive intelligence API for AI agents (v4.5.7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@
 #### Live Services
 
 - [PoolPulse](https://poolpulse.poolpulse.workers.dev) — x402-payable DeFi execution signals API on Base. CLMM slippage, MEV scoring, routing hints for 33 Uniswap V3 + Aerodrome pools. Built with Hono + x402/hono. Pay per call ($0.001–$0.25 USDC). ([OpenAPI](https://poolpulse.poolpulse.workers.dev/openapi.json), [Examples](https://github.com/HadiFrt20/poolpulse-agent-example))
+- [Intelica](https://api.intelica.dev) — Competitive intelligence API for autonomous AI agents. Analyzes any URL or company description and returns structured JSON with moat scoring (IMI 0.0–1.0), competitor mapping, decision recommendation (enter/avoid/monitor/acquire/partner), executable action plan, source verification, and OTel trace metadata. 10 modes: `competitive`, `fundraising`, `partnership`, `acquisition`, `market_entry`, `crypto_protocol`, `defend_position`, `regulatory_compliance`, `venture_screening`, `risk_assessment`. Standard $0.05 USDC / Elite $1.00 USDC on Base (`eip155:8453`) and Solana. MCP at `/mcp`. ([OpenAPI](https://api.intelica.dev/openapi.json), [x402](https://api.intelica.dev/.well-known/x402.json), [Trial](https://api.intelica.dev/api-keys/trial))
 - [Coinbase x402 Bazaar](https://docs.cdp.coinbase.com/x402/bazaar) — Discovery layer / MCP server exposing 10,000+ x402-payable endpoints that agents can search, discover, and pay for autonomously (also surfaced via AWS Bedrock AgentCore Gateway)
 
 #### SDKs & Libraries


### PR DESCRIPTION
## New Live Service: Intelica

**Section:** Developer Tools & Starters → x402 Implementation → Live Services

### What it does
Competitive intelligence API for autonomous AI agents. Analyzes any URL or company description and returns structured JSON with:
- **IMI** (Intelica Moat Index 0.0–1.0) — moat strength benchmarked against 3,744+ companies
- **Decision recommendation** — enter/avoid/monitor/acquire/partner + confidence + rationale
- **Action plan (SOP)** — executable steps with owner, deadline, and tool hints
- **Source verification** — semantic match between claims and source text
- **Audit trail** — SHA256, EU AI Act Art.13 compliant
- **OTel span metadata** — trace_id + OpenTelemetry fields

### x402 Details
- Standard: $0.05 USDC (`competitive`, `fundraising`, `partnership`, `acquisition`, `market_entry`, `crypto_protocol`)
- Elite: $1.00 USDC (`regulatory_compliance`, `venture_screening`, `risk_assessment`, `defend_position`)
- Networks: `eip155:8453` (Base) + `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` (Solana)
- x402 v2 with CAIP-2, PAYMENT-REQUIRED header, Bazaar extension metadata

### Verification
```bash
curl -i -X POST https://api.intelica.dev/intel -H "Content-Type: application/json" -d '{}'
# Returns HTTP 402 with valid x402 v2 accepts[] payload
```

### Links
- API: https://api.intelica.dev
- x402 manifest: https://api.intelica.dev/.well-known/x402.json
- OpenAPI: https://api.intelica.dev/openapi.json
- Trial (5 free calls): https://api.intelica.dev/api-keys/trial
- MCP: https://api.intelica.dev/mcp
- GitHub: https://github.com/teodorofodocrispin-cmyk/intelica-mcp
